### PR TITLE
Eklenmesi gereken Farsça dil seçeneği

### DIFF
--- a/src/features/profile/components/ProfileForm.tsx
+++ b/src/features/profile/components/ProfileForm.tsx
@@ -209,6 +209,7 @@ export const ProfileForm: React.FC<ProfileFormProps> = ({
                 <option value="zh">Çince</option>
                 <option value="ar">Arapça</option>
                 <option value="hi">Hintçe</option>
+                <option value="fa">Farsça</option>
               </select>
             </div>
 

--- a/src/features/recommendation/components/CuratedContentFilters.tsx
+++ b/src/features/recommendation/components/CuratedContentFilters.tsx
@@ -312,6 +312,7 @@ export const CuratedContentFiltersComponent: React.FC<CuratedContentFiltersProps
                 { code: 'zh', name: 'Çince', flag: '🇨🇳' },
                 { code: 'ar', name: 'Arapça', flag: '🇸🇦' },
                 { code: 'hi', name: 'Hintçe', flag: '🇮🇳' },
+                { code: 'fa', name: 'Farsça', flag: '🇮🇷' },
                 { code: 'nl', name: 'Hollandaca', flag: '🇳🇱' },
                 { code: 'sv', name: 'İsveççe', flag: '🇸🇪' },
                 { code: 'no', name: 'Norveççe', flag: '🇳🇴' },

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -7,11 +7,13 @@ import Backend from 'i18next-http-backend';
 import en from './locales/en.json';
 import tr from './locales/tr.json';
 import es from './locales/es.json';
+// import fa from './locales/fa.json'; // Persian will be added
 
 const resources = {
   en: { translation: en },
   tr: { translation: tr },
   es: { translation: es }
+  // fa: { translation: fa } // Persian will be added when locale file is created
 };
 
 // Language detection options
@@ -100,7 +102,8 @@ export default i18n;
 export const supportedLanguages = [
   { code: 'en', name: 'English', nativeName: 'English' },
   { code: 'tr', name: 'Turkish', nativeName: 'Türkçe' },
-  { code: 'es', name: 'Spanish', nativeName: 'Español' }
+  { code: 'es', name: 'Spanish', nativeName: 'Español' },
+  { code: 'fa', name: 'Persian', nativeName: 'فارسی' }
 ];
 
 export const getCurrentLanguage = () => i18n.language;


### PR DESCRIPTION
Add Persian (Farsça) language support to various selection interfaces for consistency.